### PR TITLE
Fix for Cygwin file_size function

### DIFF
--- a/dropbox_uploader.sh
+++ b/dropbox_uploader.sh
@@ -100,7 +100,7 @@ function urlencode
 #Return the file size in bytes
 function file_size
 {
-    if [ "$OSTYPE" == "linux-gnu" ]; then
+    if [ "$OSTYPE" == "linux-gnu" -o "$OSTYPE" == "cygwin" ]; then
         stat --format="%s" "$1"
         return
     else


### PR DESCRIPTION
Fix for Cygwin: use standard
stat --format="%s" in file_size command
