### PR TITLE
fixing unicode problem of list and download commands (issue #22)

### DIFF
--- a/dropbox_uploader.sh
+++ b/dropbox_uploader.sh
@@ -59,7 +59,7 @@ API_INFO_URL="https://api.dropbox.com/1/account/info"
 APP_CREATE_URL="https://www2.dropbox.com/developers/apps"
 RESPONSE_FILE="$TMP_DIR/du_resp_$RANDOM"
 CHUNK_FILE="$TMP_DIR/du_chunk_$RANDOM"
-BIN_DEPS="sed basename date grep cut stat dd"
+BIN_DEPS="sed basename date grep cut stat dd /usr/bin/printf od tr"
 VERSION="0.11.2"
 
 umask 077


### PR DESCRIPTION
- fix for `list` ignoring unicode markup:
  `/usr/bin/printf` does the unicode-to-utf8 conversion just right
- fix for `download` sending non-converted strings:
  converts url to hex-string percent encoding used for url-enconding. The server-side fully understands this even for normal `[a-zA-Z0-9]` characters, so there is no need to do more sophisticated conversion.

Tested on Fedora 17-64 only.
