### PR TITLE
Mac OS X's `readlink` doesn't support '-m'

### DIFF
--- a/dropShell.sh
+++ b/dropShell.sh
@@ -19,11 +19,29 @@
 # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 #
 
-DU="./dropbox_uploader.sh"
+# this will find `dropbox_uploader.sh` anywhere in $PATH
+DU=`command which dropbox_uploader.sh 2>/dev/null`
+
+# Mac OS X's `readlink` does not support the '-m' flag (at least as of
+# 10.8.4). The GNU readlink does. It would most likely be installed as
+# `greadlink` if it was installed via the Homebrew system.
+
+OS=`uname`
+
+case "$OS" in
+	Darwin)
+				READLINK=greadlink
+	;;
+
+	*)
+				READLINK=readlink
+	;;
+
+esac
 
 SHELL_HISTORY=~/.dropshell_history
 DU_OPT="-q"
-BIN_DEPS="id readlink ls basename ls pwd cut"
+BIN_DEPS="id ${READLINK} basename ls pwd cut"
 VERSION="0.1"
 
 umask 077
@@ -38,13 +56,12 @@ for i in $BIN_DEPS; do
 done
 
 #Check DropBox Uploader
-if [ ! -f "$DU" ]; then
 if [ ! -e "$DU" ]; then
     echo "DropBox Uploader not found: $DU"
     echo "Please change the 'DU' variable according to the DropBox Uploader location."
     exit 1
 else
-    DU=$(readlink -m "$DU")
+    DU=$(${READLINK} -m "$DU")
 fi
 
 #Returns the current user
@@ -55,7 +72,7 @@ function get_current_user
 
 function normalize_path
 {
-    readlink -m "$1"
+    ${READLINK} -m "$1"
 }
 
 ################
@@ -91,7 +108,7 @@ while (true); do
     case $cmd in
 
         ls)
-            
+
             #Listing current dir
             if [ -z "$arg1" ]; then
                 $DU $DU_OPT list "$CWD"
@@ -126,7 +143,7 @@ while (true); do
 
             CWD=$(normalize_path "$CWD/$arg1/")
             $DU $DU_OPT list "$CWD" > /dev/null
-    
+
             #Checking for errors
             if [ $? -ne 0 ]; then
                 echo -e "cd: $arg1: No such file or directory"
@@ -168,7 +185,7 @@ while (true); do
         put)
 
             if [ ! -z "$arg1" ]; then
-        
+
                 #Relative or absolute path?
                 if [ "${arg2:0:1}" == "/" ]; then
                     $DU $DU_OPT upload "$arg1" $(normalize_path "$arg2")


### PR DESCRIPTION
Just checking for `readlink` on Mac OS X isn't enough. We have to look for `greadlink` (or GNU's `readlink`) which users can install via Homebrew.

I added a simple `case` statement for comparing the output of `uname` to see if we are on Mac OS X (aka 'Darwin' according to `uname`). The `case` should also make it easier to add checks for other OSes if needed. The case statement sets the variable `${READLINK}` to `greadlink` on Darwin, but leaves it as `readlink` for any other OS.

I then replaced any occurrence of `readlink` with ${READLINK}

OH! And I changed "DU=" to use `which` to look for `dropbox_uploader.sh` anywhere in the user's $PATH rather than having to be set manually.

I think that's it.

(Sorry if I did any of this wrong, I don't really know `git` all that well, in fact this is my first pull request. Feel free to ignore if I screwed something up or if you choose not to care about Mac OS X.)
