### PR TITLE
 Skip uploading non-regular files

### DIFF
--- a/dropbox_uploader.sh
+++ b/dropbox_uploader.sh
@@ -390,7 +390,7 @@ function db_upload
         db_upload_dir "$SRC" "$DST"
 
     #It's a file
-    elif [[ -e $SRC ]]; then
+    elif [[ -f $SRC ]]; then
         db_upload_file "$SRC" "$DST"
 
     #Unsupported object...


### PR DESCRIPTION
dropbox_uploader.sh hangs when one tries to upload non regular files (i.e. block devices, fifo's, etc.)
