### PR TITLE
Allow environment variable to specify config file

### DIFF
--- a/dropbox_uploader.sh
+++ b/dropbox_uploader.sh
@@ -20,7 +20,7 @@
 #
 
 #Default configuration file
-CONFIG_FILE=~/.dropbox_uploader
+CONFIG_FILE=${DROPBOX_UPLOADER_CONFIG_FILE:-~/.dropbox_uploader}
 
 #Default chunk size in Mb for the upload process
 #It is recommended to increase this value only if you have enough free space on your /tmp partition


### PR DESCRIPTION
DROPBOX_UPLOADER_CONFIG_FILE can be used to specify the location of a configuration file.

This is useful if you're calling dropbox_uploader.sh multiple times within a script.
