### PR TITLE
Skip encode Unicode characters in urlencode.

### DIFF
--- a/dropbox_uploader.sh
+++ b/dropbox_uploader.sh
@@ -300,7 +300,8 @@ function urlencode
         c=${string:$pos:1}
         case "$c" in
             [-_.~a-zA-Z0-9] ) o="${c}" ;;
-            * ) printf -v o '%%%02x' "'$c"
+            [\x00-\xFF] ) printf -v o '%%%02x' "'$c" ;;
+            * )  o="${c}"
         esac
         encoded+="${o}"
     done


### PR DESCRIPTION
Our script handles these characters incorrectly, however
they can be handled by cURL with correct $LANG.

For example, when LANG=en_US.UTF-8:
`/自爆店` was encoded as `%2f%81ea%7206%5e97` (wrong). 

I modified this behavior. Now it will not encode Unicode characters any longer.
`/自爆店` will be encoded as `%2f自爆店`. 
cURL will encode this URL into `%2f%e8%87%aa%e7%88%86%e5%ba%97`

This solves issues with uploading file with Unicode characters.
