### PR TITLE
Add an additional check for dropbox_uploader without the .sh extension.

### DIFF
--- a/dropShell.sh
+++ b/dropShell.sh
@@ -25,11 +25,13 @@ if [ -f "./dropbox_uploader.sh" ]; then
 else
     DU=$(which dropbox_uploader.sh)
     if [ $? -ne 0 ]; then
-        echo "Dropbox Uploader not found!"
-        exit 1
+        DU=$(which dropbox_uploader)
+        if [ $? -ne 0 ]; then
+          echo "Dropbox Uploader not found!"
+          exit 1
+        fi
     fi
 fi
-
 #For MacOSX, install coreutils (which includes greadlink)
 # $brew install coreutils
 if [ "${OSTYPE:0:6}" == "darwin" ]; then


### PR DESCRIPTION
Tries one more time to find dropbox_uploader, by looking for it without the .sh This is useful for users who have added dropbox_uploader on their path.
