### PR TITLE
Metadata

### DIFF
--- a/dropbox_uploader.sh
+++ b/dropbox_uploader.sh
@@ -764,16 +764,6 @@ function db_download_file
         return
     fi
 
-    #Creating the empty file, that for two reasons:
-    #1) In this way I can check if the destination file is writable or not
-    #2) Curl doesn't automatically creates files with 0 bytes size
-    dd if=/dev/zero of="$FILE_DST" count=0 2> /dev/null
-    if [[ $? != 0 ]]; then
-        print " > Error writing file $FILE_DST: permission denied\n"
-        ERROR_STATUS=1
-        return
-    fi
-
     #Don't download files with modified timestamps equal or higher than upstream if -m is present.
     if [[ -e $FILE_DST && $CHECK_MODIFIED == 1 ]]; then
       #Checking if the file has changed
@@ -787,6 +777,16 @@ function db_download_file
         echo "File '"$FILE_SRC"' up to date, skipping as requested by -m flag."
         return
       fi
+    fi
+
+    #Creating the empty file, that for two reasons:
+    #1) In this way I can check if the destination file is writable or not
+    #2) Curl doesn't automatically creates files with 0 bytes size
+    dd if=/dev/zero of="$FILE_DST" count=0 2> /dev/null
+    if [[ $? != 0 ]]; then
+        print " > Error writing file $FILE_DST: permission denied\n"
+        ERROR_STATUS=1
+        return
     fi
 
     print " > Downloading \"$FILE_SRC\" to \"$FILE_DST\"... $LINE_CR"

--- a/dropbox_uploader.sh
+++ b/dropbox_uploader.sh
@@ -226,6 +226,7 @@ function usage
     echo -e "\t mkdir    <REMOTE_DIR>"
     echo -e "\t list     [REMOTE_DIR]"
     echo -e "\t share    <REMOTE_FILE>"
+    echo -e "\t metadata <REMOTE_FILE/DIR>"
     echo -e "\t info"
     echo -e "\t unlink"
 
@@ -340,6 +341,18 @@ function normalize_path
     else
         echo "$path"
     fi
+}
+
+#Get metadata for a remote file/dir
+#$1 = Remote file
+function db_metadata
+{
+    local FILE=$(normalize_path "$1")
+
+    print " > Getting metadata for \"$FILE\"... $LINE_CR"
+    $CURL_BIN $CURL_ACCEPT_CERTIFICATES -s --show-error --globoff -i -o "$RESPONSE_FILE" "$API_METADATA_URL/$ACCESS_LEVEL/$(urlencode "$FILE")?oauth_consumer_key=$APPKEY&oauth_token=$OAUTH_ACCESS_TOKEN&oauth_signature_method=PLAINTEXT&oauth_signature=$APPSECRET%26$OAUTH_ACCESS_TOKEN_SECRET&oauth_timestamp=$(utime)&oauth_nonce=$RANDOM" 2> /dev/null
+    check_http_response
+    sed '1,/^\r\{0,1\}$/d' $RESPONSE_FILE
 }
 
 #Check if it's a file or directory
@@ -1212,6 +1225,18 @@ case $COMMAND in
         FILE_DST=$ARG1
 
         db_share "/$FILE_DST"
+
+    ;;
+
+    metadata)
+
+        if [[ $argnum -lt 1 ]]; then
+            usage
+        fi
+
+        FILE_DST=$ARG1
+
+        db_metadata "/$FILE_DST"
 
     ;;
 


### PR DESCRIPTION
Add a flag to skip downloading the file if the local timestamp is fresh (>= than the remote one).

Contents:
- Add action 'metadata' to fetch the metadata for a file/dir, example usage:

``` bash
./dropbox_uploader.sh metadata "This is your Dropbox.txt"
 > Getting metadata for "/This is your Dropbox.txt"... 
{"read_only": false, "revision": 510112379, "bytes": 240, "thumb_exists": false, "rev": "1e67b27b0017a723", "modified": "Sun, 15 Mar 2009 00:01:33 +0000", "mime_type": "text/plain", "size": "240 bytes", "path": "/This is your Dropbox.txt", "is_dir": false, "modifier": null, "root": "dropbox", "client_mtime": "Sat, 14 Mar 2009 17:01:33 +0000", "icon": "page_white_text"}
```
- Add -m flag that works only for 'download' action, and skips the download of files that have fresh modified timestamps; example usage:

``` bash
./dropbox_uploader.sh -m download "This is your Dropbox.txt" 
File '/This is your Dropbox.txt' up to date, skipping as requested by -m flag.
```

Feel free to comment for required updates.
