### PR TITLE
Pass URL-string through bash built-in echo to convert \uXXXX encoded Unicode sequences to UTF-8

### DIFF
--- a/dropbox_uploader.sh
+++ b/dropbox_uploader.sh
@@ -315,7 +315,7 @@ function check_http_response
 #Urlencode
 function urlencode
 {
-    local string="${1}"
+    local string=$(echo -e "${1}")
     local strlen=${#string}
     local encoded=""
 


### PR DESCRIPTION
Please check implication when passing the URL-String through "echo -e".

Note: Local file name still contains the \uXXXX string. Need to fix this too.