### PR TITLE
Option -h with list command shows file sizes in human readable format

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ Enable DEBUG mode
 * **-q**  
 Quiet mode. Don't show progress meter or messages
 
+* **-h**  
+Show file sizes in human readable format
+
 * **-p**  
 Show cURL progress meter
 

--- a/dropbox_uploader.sh
+++ b/dropbox_uploader.sh
@@ -262,6 +262,7 @@ function usage
     echo -e "\t-s            Skip already existing files when download/upload. Default: Overwrite"
     echo -e "\t-d            Enable DEBUG mode"
     echo -e "\t-q            Quiet mode. Don't show messages"
+    echo -e "\t-h            Show file sizes in human readable format"
     echo -e "\t-p            Show cURL progress meter"
     echo -e "\t-k            Doesn't check for SSL certificates (insecure)"
 

--- a/dropbox_uploader.sh
+++ b/dropbox_uploader.sh
@@ -75,7 +75,7 @@ shopt -s nullglob #Bash allows filename patterns which match no files to expand 
 shopt -s dotglob  #Bash includes filenames beginning with a "." in the results of filename expansion
 
 #Look for optional config file parameter
-while getopts ":qpskdf:" opt; do
+while getopts ":qpskdhf:" opt; do
     case $opt in
 
     f)
@@ -100,6 +100,10 @@ while getopts ":qpskdf:" opt; do
 
     s)
       SKIP_EXISTING_FILES=1
+    ;;
+
+    h)
+      HUMAN_READABLE_SIZE=1
     ;;
 
     \?)
@@ -184,6 +188,24 @@ function remove_temp_files
         rm -fr "$RESPONSE_FILE"
         rm -fr "$CHUNK_FILE"
         rm -fr "$TEMP_FILE"
+    fi
+}
+
+#Converts bytes to human readable format
+function convert_bytes
+{
+    if [[ $HUMAN_READABLE_SIZE == 1 ]]; then
+	if (($1 > 1073741824));then
+	    echo $(($1/1073741824)).$(($1%1073741824/100000000))"G";
+	elif (($1 > 1048576));then
+	    echo $(($1/1048576)).$(($1%1048576/100000))"M";
+	elif (($1 > 1024));then
+	    echo $(($1/1024)).$(($1%1024/100))"K";
+	else
+	    echo $1;
+	fi
+    else
+	echo $1;
     fi
 }
 
@@ -999,7 +1021,7 @@ function db_list
 
                 local FILE=$(echo "$line" | sed -n 's/.*"path": *"\([^"]*\)".*/\1/p')
                 local IS_DIR=$(echo "$line" | sed -n 's/.*"is_dir": *\([^,]*\).*/\1/p')
-                local SIZE=$(echo "$line" | sed -n 's/.*"bytes": *\([0-9]*\).*/\1/p')
+                local SIZE=$(convert_bytes $(echo "$line" | sed -n 's/.*"bytes": *\([0-9]*\).*/\1/p'))
 
                 echo -e "$FILE:$IS_DIR;$SIZE" >> "$RESPONSE_FILE"
 


### PR DESCRIPTION
## New option: -h

Like many Unix commands this program now accepts -h option to output file sizes in human understandable format instead of bytes.

It does not add any dependency and the the application acts exactly as before if you do not want to use the -h option.

### Example

    ./dropbox_uploader.sh -h list
    > Listing "//"... DONE
     [D] 0          App
     [F] 2.0K       File.txt
