### PR TITLE
Added a makefile for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Then give the execution permission to the script and run it:
  $./dropbox_uploader.sh
 ```
 
+Alternatively install the script by running:
+
+```bash
+ $make install
+```
+
 The first time you run `dropbox_uploader`, you'll be guided through a wizard in order to configure access to your Dropbox. This configuration will be stored in `~/.dropbox_uploader`.
 
 ### Configuration wizard

--- a/makefile
+++ b/makefile
@@ -3,9 +3,7 @@ all:
 	@echo "Run 'make uninstall' for uninstallation."
 
 install:
-	cp dropbox_uploader.sh /usr/bin/dropbox_uploader.sh
-	cp dropShell.sh /usr/bin/dropShell.sh
+	install -vb -m 755 drop{box_uploader,Shell}.sh /usr/local/bin
 
 uninstall:
-	rm /usr/bin/dropbox_uploader.sh
-	rm /usr/bin/dropShell.sh
+	rm /usr/local/bin/drop{box_uploader,Shell}.sh

--- a/makefile
+++ b/makefile
@@ -1,0 +1,11 @@
+all:
+	@echo "Run 'make install' for installation."
+	@echo "Run 'make uninstall' for uninstallation."
+
+install:
+	cp dropbox_uploader.sh /usr/bin/dropbox_uploader.sh
+	cp dropShell.sh /usr/bin/dropShell.sh
+
+uninstall:
+	rm /usr/bin/dropbox_uploader.sh
+	rm /usr/bin/dropShell.sh


### PR DESCRIPTION
I have added a makefile so that the script can be installed to the `/usr/bin` directory by running `make install`. It would eliminate the need to manually add the script to execution path. The users will be able to run the script by simply running `dropbox_uploader.sh <parameters>` at command line.

The makefile also has uninstall support besides installation.
