### PR TITLE
Added limit rate option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Dropbox Uploader
 
-Dropbox Uploader is a **BASH** script which can be used to upload, download, delete, list files (and more!) from **Dropbox**, an online file sharing, synchronization and backup service. 
+Dropbox Uploader is a **BASH** script which can be used to upload, download, delete, list files (and more!) from **Dropbox**, an online file sharing, synchronization and backup service.
 
 It's written in BASH scripting language and only needs **cURL**.
 
 **Why use this script?**
 
 * **Portable:** It's written in BASH scripting and only needs *cURL* (curl is a tool to transfer data from or to a server, available for all operating systems and installed by default in many linux distributions).
-* **Secure:** It's not required to provide your username/password to this script, because it uses the official Dropbox API for the authentication process. 
+* **Secure:** It's not required to provide your username/password to this script, because it uses the official Dropbox API for the authentication process.
 
 Please refer to the &lt;Wiki&gt;(https://github.com/andreafabrizi/Dropbox-Uploader/wiki) for tips and additional information about this project. The Wiki is also the place where you can share your scripts and examples related to Dropbox Uploader.
 
@@ -64,67 +64,70 @@ The syntax is quite simple:
 
 **Available commands:**
 
-* **upload** &lt;LOCAL_FILE/DIR ...&gt; &lt;REMOTE_FILE/DIR&gt;  
-Upload a local file or directory to a remote Dropbox folder.  
-If the file is bigger than 150Mb the file is uploaded using small chunks (default 4Mb); 
-in this case a . (dot) is printed for every chunk successfully uploaded and a * (star) if an error 
+* **upload** &lt;LOCAL_FILE/DIR ...&gt; &lt;REMOTE_FILE/DIR&gt;
+Upload a local file or directory to a remote Dropbox folder.
+If the file is bigger than 150Mb the file is uploaded using small chunks (default 4Mb);
+in this case a . (dot) is printed for every chunk successfully uploaded and a * (star) if an error
 occurs (the upload is retried for a maximum of three times).
 Only if the file is smaller than 150Mb, the standard upload API is used, and if the -p option is used
-the default curl progress bar is displayed during the upload process.  
+the default curl progress bar is displayed during the upload process.
 The local file/dir parameter supports wildcards expansion.
 
-* **download** &lt;REMOTE_FILE/DIR&gt; [LOCAL_FILE/DIR]  
+* **download** &lt;REMOTE_FILE/DIR&gt; [LOCAL_FILE/DIR]
 Download file or directory from Dropbox to a local folder
 
-* **delete** &lt;REMOTE_FILE/DIR&gt;  
+* **delete** &lt;REMOTE_FILE/DIR&gt;
 Remove a remote file or directory from Dropbox
 
-* **move** &lt;REMOTE_FILE/DIR&gt; &lt;REMOTE_FILE/DIR&gt;  
+* **move** &lt;REMOTE_FILE/DIR&gt; &lt;REMOTE_FILE/DIR&gt;
 Move or rename a remote file or directory
 
-* **copy** &lt;REMOTE_FILE/DIR&gt; &lt;REMOTE_FILE/DIR&gt;  
+* **copy** &lt;REMOTE_FILE/DIR&gt; &lt;REMOTE_FILE/DIR&gt;
 Copy a remote file or directory
 
-* **mkdir** &lt;REMOTE_DIR&gt;  
+* **mkdir** &lt;REMOTE_DIR&gt;
 Create a remote directory on DropBox
 
-* **list** [REMOTE_DIR]  
+* **list** [REMOTE_DIR]
 List the contents of the remote Dropbox folder
 
-* **share** &lt;REMOTE_FILE&gt;  
+* **share** &lt;REMOTE_FILE&gt;
 Get a public share link for the specified file or directory
 
-* **saveurl** &lt;URL&gt; &lt;REMOTE_DIR&gt;  
+* **saveurl** &lt;URL&gt; &lt;REMOTE_DIR&gt;
 Download a file from an URL to a Dropbox folder directly (the file is NOT downloaded locally)
 
-* **info**  
+* **info**
 Print some info about your Dropbox account
 
-* **unlink**  
+* **unlink**
 Unlink the script from your Dropbox account
 
 
-**Optional parameters:**  
-* **-f &lt;FILENAME&gt;**  
+**Optional parameters:**
+* **-f &lt;FILENAME&gt;**
 Load the configuration file from a specific file
 
-* **-s**  
+* **-s**
 Skip already existing files when download/upload. Default: Overwrite
 
-* **-d**  
+* **-d**
 Enable DEBUG mode
 
-* **-q**  
+* **-q**
 Quiet mode. Don't show progress meter or messages
 
-* **-h**  
+* **-h**
 Show file sizes in human readable format
 
-* **-p**  
+* **-p**
 Show cURL progress meter
 
-* **-k**  
+* **-k**
 Doesn't check for SSL certificates (insecure)
+
+* **-l**
+Limit upload rate with `curl --limit-rate` option. Example `-l 500K`
 
 
 **Examples:**
@@ -155,7 +158,7 @@ Doesn't check for SSL certificates (insecure)
 If you have successfully tested this script on others systems or platforms please let me know!
 
 ## Running as cron job
-Dropbox Uploader relies on a different configuration file for each system user. The default configuration file location is HOME_DIRECTORY/.dropbox_uploader. This means that if you do the setup with your user and then you try to run a cron job as root, it won't works.  
+Dropbox Uploader relies on a different configuration file for each system user. The default configuration file location is HOME_DIRECTORY/.dropbox_uploader. This means that if you do the setup with your user and then you try to run a cron job as root, it won't works.
 So, when running this script using cron, please keep in mind the following:
 * Remember to setup the script with the user used to run the cron job
 * Use always the -f option to specify the full configuration file path, because sometimes in the cron environment the home folder path is not detected correctly
@@ -178,7 +181,7 @@ To use a proxy server, just set the **https_proxy** environment variable:
     setenv HTTP_PROXY_PASSWORD YYYY
     setenv https_proxy http://192.168.0.1:8080
 ```
-   
+
 ## BASH and Curl installation
 
 **Debian & Ubuntu Linux:**
@@ -193,8 +196,8 @@ To use a proxy server, just set the **https_proxy** environment variable:
     cd /usr/ports/ftp/curl && make install clean
 ```
 
-**Cygwin:**  
-You need to install these packages:  
+**Cygwin:**
+You need to install these packages:
 * curl
 * ca-certificates
 * dos2unix

--- a/dropbox_uploader.sh
+++ b/dropbox_uploader.sh
@@ -171,7 +171,7 @@ fi
 function print
 {
     if [[ $QUIET == 0 ]]; then
-	    echo -ne "$1";
+        echo -ne "$1";
     fi
 }
 
@@ -195,17 +195,17 @@ function remove_temp_files
 function convert_bytes
 {
     if [[ $HUMAN_READABLE_SIZE == 1 ]]; then
-	if (($1 > 1073741824));then
-	    echo $(($1/1073741824)).$(($1%1073741824/100000000))"G";
-	elif (($1 > 1048576));then
-	    echo $(($1/1048576)).$(($1%1048576/100000))"M";
-	elif (($1 > 1024));then
-	    echo $(($1/1024)).$(($1%1024/100))"K";
-	else
-	    echo $1;
-	fi
+        if (($1 > 1073741824));then
+            echo $(($1/1073741824)).$(($1%1073741824/100000000))"G";
+        elif (($1 > 1048576));then
+            echo $(($1/1048576)).$(($1%1048576/100000))"M";
+        elif (($1 > 1024));then
+            echo $(($1/1024)).$(($1%1024/100))"K";
+        else
+            echo $1;
+        fi
     else
-	echo $1;
+    echo $1;
     fi
 }
 
@@ -217,7 +217,7 @@ function file_size
     if [ $? -eq 0 ]; then
         echo $SIZE
         return
-    fi   
+    fi
 
     #Some embedded linux devices
     SIZE=$(stat -c "%s" "$1" 2> /dev/null)


### PR DESCRIPTION
Hi, 

I added an option to limit upload rate wit curl, I also added it to the usage description and to the readme file. I think this might be a useful feature for others too, so here is my pull request.

As a by-product I also optimized some tabs/spaces issues in the dropbox_uploader.sh and trailing spaces occurrences in README.md. The editor trimmed them automatically while during save.

Please let me know if you can merge the changes or if there is something to improve.

Thanks!
