### PR TITLE
NEW: additional output of shared link string into _link.txt

### DIFF
--- a/dropbox_uploader.sh
+++ b/dropbox_uploader.sh
@@ -1034,6 +1034,7 @@ function db_share
         print " > Share link: "
         SHARE_LINK=$(sed -n 's/.*"url": "\([^"]*\).*/\1/p' "$RESPONSE_FILE")
         echo "$SHARE_LINK"
+        echo "$SHARE_LINK" > _link.txt
     else
         print "FAILED\n"
         ERROR_STATUS=1


### PR DESCRIPTION
In order to be able to easily use the Dropbox file link generated from this tool, this commit provides a temporary file output `_link.txt` which holds the generated Dropbox link string. The file can then be read out from e.g. a python code snippet (see below) to further use its contents. Thus, the link string can easily be provided e.g. via eMail (rather than only read from the console window).

``` python
import os

# call dropbox-updater tool
command = <ToolPath> + ' share ' + <myDropboxDestFolder> + '/' + <myDropboxFile>
os.system(command)

# read file containing link
strSharedDropboxFolderPath = open('_link.txt', 'rb').readline().decode('utf-8')

# delete temporary file
os.system('rm _link.txt')
```

The variables `<ToolPath>`, `<myDropboxDestFolder>` and `<myDropboxFile>` must be exchanged to real strings in order to run this snippet in Python. It just shows an example usage to grasp the idea. Maybe, there would be a more elegant way to provide a computable link string, but this was the first solution which came to mind. What do you think?
