### PR TITLE
Flag to skip download if the file revision hasn't changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ Load the configuration file from a specific file
 * **-s**  
 Skip already existing files when download/upload. Default: Overwrite
 
+* **-S** 
+(Beta) Download the server version if it has changed revision (/!\ the local changed will be lost /!\
+
 * **-d**  
 Enable DEBUG mode
 
@@ -227,8 +230,3 @@ andrea@Dropbox:/$ ls
 andrea@DropBox:/ServerBackup$ get notes.txt
 ```
 
-## Donations
-
- If you want to support this project, please consider donating:
- * PayPal: andrea.fabrizi@gmail.com
- * BTC: 1JHCGAMpKqUwBjcT3Kno9Wd5z16K6WKPqG


### PR DESCRIPTION
I added a flag to indicate that the file must be downloaded only if the revision has changed
In each directory, a .dropbox hidden directory was created, with inside the same files present in the parent folder, but with content as the revision of the original file

example:
screen/day.png
screen/night.png
screen/.dropbox/day.png (contents:1fd6b03d194d0)
screen/.dropbox/night.png (contents:1fd6C03d194d1)


A good way to have a strong backup from Dropbox