### PR TITLE
Fix one-line bug in db_download() in dropbox_uploader.sh

### DIFF
--- a/dropbox_uploader.sh
+++ b/dropbox_uploader.sh
@@ -715,7 +715,7 @@ function db_download
         while read -r line; do
 
             local FILE=${line%:*}
-            local TYPE=${line#*:}
+            local TYPE=${line##*:}
 
             FILE=${FILE##*/}
 


### PR DESCRIPTION
Bug fix.
In all other places file listing data was split using "${line##*:}", which works if the filename contains a ":".
In this place it was missed, and was only using "${line#*:}"