### PR TITLE
Use greadlink (coreutils) also for FreeBSD

### DIFF
--- a/dropShell.sh
+++ b/dropShell.sh
@@ -32,7 +32,7 @@ fi
 
 #For MacOSX, install coreutils (which includes greadlink)
 # $brew install coreutils
-if [ "${OSTYPE:0:6}" == "darwin" ]; then
+if [ "${OSTYPE:0:6}" == "darwin" -o "${OSTYPE:0:7}" == "freebsd" ]; then
     READLINK="greadlink"
 else
     READLINK="readlink"


### PR DESCRIPTION
Dropbox Uploader needs greadlink from coreutils under FreeBSD.
This patch is already included in the FreeBSD port.
(see https://svnweb.freebsd.org/ports/head/net/dropbox-uploader/Makefile?revision=421172&view=markup )