### PR TITLE
Possibility to run the script via docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:3.5
+MAINTAINER peez@stiffi.de
+
+RUN apk add --no-cache bash curl
+COPY / /opt/dropbox_uploader
+RUN mkdir -p /config && mkdir -p /workdir
+
+VOLUME /config /workdir
+
+WORKDIR /workdir
+
+ENTRYPOINT ["/opt/dropbox_uploader/dropbox_uploader.sh", "-f", "/config/dropbox_uploader.conf"]

--- a/README.md
+++ b/README.md
@@ -236,6 +236,18 @@ andrea@Dropbox:/$ ls
 andrea@DropBox:/ServerBackup$ get notes.txt
 ```
 
+## Running as Docker Container
+If you have installed docker on your system and don't want to deal with downloading the script and ensuring the correct curl versions etc., you can run Dropbox-Uploader via docker as well:
+```bash
+andrea@Dropbox:/$ docker run -it --rm --user=$(id -u):$(id -g) -v <LOCAL_CONFIG_PATH>:/config -v <YOUR_DATA_DIR_MOUNT> peez/dropbox-uploader <Arguments> 
+```
+This will store the auth token information in the given local directory in `<LOCAL_CONFIG_PATH>`. To ensure access to your mounted directories it can be important to pass a UID and GID to the docker deamon (as stated in the example by the --user argument)
+
+Using the script with docker makes it also possible to run the script even on windows machines.
+
+To use a proxy, just set the mentioned environment variables via the docker `-e` parameter.
+
+
 ## Donations
 
  If you want to support this project, please consider donating:


### PR DESCRIPTION
I don't like dealing with downloading scripts to the correct paths, maintaining these paths etc.

Therefore I wrote a small Dockerfile that encapsulates that.
Once you accepted the pull request we can also replace the peez/dropbox-uploader with your own docker user if you have one.