### PR TITLE
Fix some code quality issues marked by shellcheck

### DIFF
--- a/dropbox_uploader.sh
+++ b/dropbox_uploader.sh
@@ -189,7 +189,7 @@ function print
 #Returns unix timestamp
 function utime
 {
-    echo $(date +%s)
+    date '+%s'
 }
 
 #Remove temporary files
@@ -377,7 +377,7 @@ function normalize_path
         new_path=$(readlink -m "$path")
 
         #Adding back the final slash, if present in the source
-        if [[ ${path: -1} == "/" && ${#path} > 1 ]]; then
+        if [[ ${path: -1} == "/" && ${#path} -gt 1 ]]; then
             new_path="$new_path/"
         fi
 
@@ -580,7 +580,7 @@ function db_chunked_upload_file
     SESSION_ID=$(sed -n 's/{"session_id": *"*\([^"]*\)"*.*/\1/p' "$RESPONSE_FILE")
 
     #Uploading chunks...
-    while ([[ $OFFSET != $FILE_SIZE ]]); do
+    while ([[ $OFFSET != "$FILE_SIZE" ]]); do
 
         let OFFSET_MB=$OFFSET/1024/1024
 
@@ -904,7 +904,7 @@ function db_account_space
         let used_mb=$used/1024/1024
         echo -e "Used:\t$used_mb Mb"
 
-        let free_mb=($quota-$used)/1024/1024
+		let free_mb=$((quota-used))/1024/1024
         echo -e "Free:\t$free_mb Mb"
 
         echo ""
@@ -919,7 +919,7 @@ function db_account_space
 function db_unlink
 {
     echo -ne "Are you sure you want unlink this script from your Dropbox account? [y/n]"
-    read answer
+    read -r answer
     if [[ $answer == "y" ]]; then
         rm -fr "$CONFIG_FILE"
         echo -ne "DONE\n"
@@ -1416,10 +1416,10 @@ else
     echo -ne " under the 'Generated access token' section, then copy and paste the new access token here:\n\n"
 
     echo -ne " # Access token: "
-    read OAUTH_ACCESS_TOKEN
+    read -r OAUTH_ACCESS_TOKEN
 
     echo -ne "\n > The access token is $OAUTH_ACCESS_TOKEN. Looks ok? [y/N]: "
-    read answer
+    read -r answer
     if [[ $answer != "y" ]]; then
         remove_temp_files
         exit 1
@@ -1436,9 +1436,9 @@ fi
 #### START  ####
 ################
 
-COMMAND=${@:$OPTIND:1}
-ARG1=${@:$OPTIND+1:1}
-ARG2=${@:$OPTIND+2:1}
+COMMAND=${*:$OPTIND:1}
+ARG1=${*:$OPTIND+1:1}
+ARG2=${*:$OPTIND+2:1}
 
 let argnum=$#-$OPTIND
 
@@ -1451,10 +1451,10 @@ case $COMMAND in
             usage
         fi
 
-        FILE_DST=${@:$#:1}
+        FILE_DST=${*:$#:1}
 
-        for (( i=$OPTIND+1; i<$#; i++ )); do
-            FILE_SRC=${@:$i:1}
+        for (( i=OPTIND+1; i<$#; i++ )); do
+            FILE_SRC=${*:$i:1}
             db_upload "$FILE_SRC" "/$FILE_DST"
         done
 


### PR DESCRIPTION
- Fix SC1036: `Change arithmetic parenthesis () to $(())` (breaks shellcheck parsing)
- Fix [SC2004: `$/${} is unnecessary on arithmetic variables`](https://github.com/koalaman/shellcheck/wiki/SC2004)
- Fix [SC2005: `Useless echo`](https://github.com/koalaman/shellcheck/wiki/SC2005)
- Fix [SC2071: `> is for string comparisons. Use -gt instead.`](https://github.com/koalaman/shellcheck/wiki/SC2071)
- Fix [SC2053: `Quote the rhs of != in [[ ]] to prevent glob matching.`](https://github.com/koalaman/shellcheck/wiki/SC2053)
- Fix [SC2162: `read without -r will mangle backslashes.`](https://github.com/koalaman/shellcheck/wiki/SC2162)
- Fix [SC2124: `Assigning an array to a string! Assign as array, or use * instead of @ to concatenate.`](https://github.com/koalaman/shellcheck/wiki/SC2124)

There are more issues than can be fixed and code improved in several parts, if this one goes through I could continue doing the work.