### PR TITLE
Use realpath instead of greadlink on FreeBSD

### DIFF
--- a/dropShell.sh
+++ b/dropShell.sh
@@ -32,7 +32,7 @@ fi
 
 #For MacOSX, install coreutils (which includes greadlink)
 # $brew install coreutils
-if [ "${OSTYPE:0:6}" == "darwin" -o "${OSTYPE:0:7}" == "freebsd" ]; then
+if [ "${OSTYPE:0:6}" == "darwin" ]; then
     READLINK="greadlink"
 else
     READLINK="readlink"

--- a/dropShell.sh
+++ b/dropShell.sh
@@ -54,24 +54,29 @@ for i in $BIN_DEPS; do
     fi
 done
 
+function normalize_path
+{
+    if [ "${OSTYPE:0:7}" == "FreeBSD" ]; then
+        p=$(realpath "$1")
+    else
+        p=$($READLINK -m "$1")
+    fi
+    echo "$p"
+}
+
 #Check DropBox Uploader
 if [ ! -f "$DU" ]; then
     echo "Dropbox Uploader not found: $DU"
     echo "Please change the 'DU' variable according to the Dropbox Uploader location."
     exit 1
 else
-    DU=$($READLINK -m "$DU")
+    DU=$(normalize_path "$DU")
 fi
 
 #Returns the current user
 function get_current_user
 {
     id -nu
-}
-
-function normalize_path
-{
-    $READLINK -m "$1"
 }
 
 ################


### PR DESCRIPTION
FreeBSD has realpath that can be used instead of greadlink -m to normalize file paths.
This has the advantage of reducing the runtime dependency to bash and cURL only.

Related to: #319