### PR TITLE
fix relative path names

### DIFF
--- a/dropShell.sh
+++ b/dropShell.sh
@@ -19,9 +19,10 @@
 # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 #
 
+CURRENT_PATH=$(cd `dirname $0`; pwd)
 #Looking for dropbox uploader
-if [ -f "./dropbox_uploader.sh" ]; then
-    DU="./dropbox_uploader.sh"
+if [ -f "$CURRENT_PATH/dropbox_uploader.sh" ]; then
+    DU="$CURRENT_PATH/dropbox_uploader.sh"
 else
     DU=$(which dropbox_uploader.sh)
     if [ $? -ne 0 ]; then
@@ -38,7 +39,7 @@ else
     READLINK="readlink"
 fi
 
-SHELL_HISTORY=~/.dropshell_history
+SHELL_HISTORY=$CURRENT_PATH/.dropshell_history
 DU_OPT="-q"
 BIN_DEPS="id $READLINK ls basename ls pwd cut"
 VERSION="0.2"

--- a/dropbox_uploader.sh
+++ b/dropbox_uploader.sh
@@ -20,7 +20,8 @@
 #
 
 #Default configuration file
-CONFIG_FILE=~/.dropbox_uploader
+CURRENT_PATH=$(cd `dirname $0`; pwd)
+CONFIG_FILE=$CURRENT_PATH/.dropbox_uploader
 
 #Default chunk size in Mb for the upload process
 #It is recommended to increase this value only if you have enough free space on your /tmp partition

--- a/testUnit.sh
+++ b/testUnit.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-DU=./dropbox_uploader.sh
+CURRENT_PATH=$(cd `dirname $0`; pwd)
+DU=$CURRENT_PATH/dropbox_uploader.sh
 
 function check_exit
 {


### PR DESCRIPTION
1. Fix relative path names "./", in case current working directory is not "./".
2. Move configuration file and history record file to the path where dropbox_uploader.sh is.