### PR TITLE
add direct_only=true in function get_Share

### DIFF
--- a/dropbox_uploader.sh
+++ b/dropbox_uploader.sh
@@ -1292,7 +1292,7 @@ function db_share
 function get_Share
 {
     local FILE_DST=$(normalize_path "$1")
-    $CURL_BIN $CURL_ACCEPT_CERTIFICATES -X POST -L -s --show-error --globoff -i -o "$RESPONSE_FILE" --header "Authorization: Bearer $OAUTH_ACCESS_TOKEN" --header "Content-Type: application/json" --data "{\"path\": \"$FILE_DST\"}" "$API_SHARE_LIST"
+    $CURL_BIN $CURL_ACCEPT_CERTIFICATES -X POST -L -s --show-error --globoff -i -o "$RESPONSE_FILE" --header "Authorization: Bearer $OAUTH_ACCESS_TOKEN" --header "Content-Type: application/json" --data "{\"path\": \"$FILE_DST\",\"direct_only\": true}" "$API_SHARE_LIST"
     check_http_response
 
     #Check


### PR DESCRIPTION
As per Dropbox' documentation (https://www.dropbox.com/developers/documentation/http/documentation#sharing-list_shared_links), if you don't specify "direct_only": true, you'll get all the shared parent folders' links along with the one you requested.

The **sed** here (https://github.com/andreafabrizi/Dropbox-Uploader/blob/master/dropbox_uploader.sh#L1301) will get the last "url" attribute it finds, so if you want to share a file that resides in a shared folder, you'll get the link for the folder and not for the file you were expecting.
