### PR TITLE
Fix for sed: 1: "s/\([0-9A-F]\{2\}\)/\\\ ...": bad flag in substitute command: 'I' #378 

### DIFF
--- a/dropbox_uploader.sh
+++ b/dropbox_uploader.sh
@@ -1445,7 +1445,7 @@ function db_sha_local
         let SKIP=$SKIP+1
     done
 
-    echo $SHA_CONCAT | sed 's/\([0-9A-F]\{2\}\)/\\\\\\x\1/gI' | xargs printf | shasum -a 256 | awk '{print $1}'
+    echo $SHA_CONCAT | xxd -r -p | shasum -a 256 | awk '{print $1}'
 }
 
 ################


### PR DESCRIPTION
#378 

Use xxd instead of sed | xargs to convert shasum output to binary.