### PR TITLE
Incorporate check for curl exit code 77 

### DIFF
--- a/dropbox_uploader.sh
+++ b/dropbox_uploader.sh
@@ -307,7 +307,7 @@ function check_http_response
         ;;
 
         #Missing CA certificates
-        60|58)
+        60|58|77)
             print "\nError: cURL is not able to performs peer SSL certificate verification.\n"
             print "Please, install the default ca-certificates bundle.\n"
             print "To do this in a Debian/Ubuntu based system, try:\n"


### PR DESCRIPTION
Hi Team

Recently encountered a problem where the script would fail if curl returned an error accessing the ca-certificates file. Rather than have the script fail, I added a check for curl exit code 77 into the check_http_response function where there is already a check for exit codes 60 & 58.
