### PR TITLE
If no shasum, try sha256sum instead

### DIFF
--- a/dropbox_uploader.sh
+++ b/dropbox_uploader.sh
@@ -1501,8 +1501,8 @@ function db_sha_local
         then
             local SHA=$(sha256sum "$CHUNK_FILE" | awk '{print $1}')
         else
-            local SHA=$(sha256sum "$CHUNK_FILE" | awk '{print $1}')
-        fi 
+            local SHA=$(shasum -a 256 "$CHUNK_FILE" | awk '{print $1}')
+        fi
         SHA_CONCAT="${SHA_CONCAT}${SHA}"
 
         let OFFSET=$OFFSET+4194304
@@ -1513,7 +1513,7 @@ function db_sha_local
     if (( $IS_SHA256SUM  == 1 ))
     then
         echo -ne $shaHex | sha256sum | awk '{print $1}'
-    else 
+    else
         echo -ne $shaHex | shasum -a 256 | awk '{print $1}'
     fi
 }


### PR DESCRIPTION
For Centos7, and perhaps other distros, coreutils no longer have a shasum utility.  The individual bitsize   parameter (-a) was removed, and instead there are individual versions named sha{bitsize}sum.  This patch checks for shasum, and if not found, looks for sha256sum and will use that instead.  I also added suppression of standard error to eliminate the not found error message that would otherwise be generated for every file.