### PR TITLE
Fix folder creation error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## Version _._ - __ ___ 20__
+* Fix issue #371: Creating directory exits 1 if it already exists
+
 ## Version 1.0 - 10 Aug 2016
 * Add search option
 * Increase chunk size to 50MB for better performance

--- a/dropbox_uploader.sh
+++ b/dropbox_uploader.sh
@@ -2,7 +2,7 @@
 #
 # Dropbox Uploader
 #
-# Copyright (C) 2010-2017 Andrea Fabrizi <andrea.fabrizi@gmail.com>
+# Copyright (C) 2010-2021 Andrea Fabrizi <andrea.fabrizi@gmail.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -1118,7 +1118,7 @@ function db_mkdir
     #Check
     if grep -q "^HTTP/[12].* 200" "$RESPONSE_FILE"; then
         print "DONE\n"
-    elif grep -q "^HTTP/[12].* 403" "$RESPONSE_FILE"; then
+    elif grep -q "{\"error_summary\": \"path/conflict/folder/" "$RESPONSE_FILE"; then
         print "ALREADY EXISTS\n"
     else
         print "FAILED\n"


### PR DESCRIPTION
Response code for conflict is HTTP/409 but this is not enought to determine if folder exists or not, since file conlicts also return 409. Use actual error_summary to determine if folder exists or not.
Resolves #371