### PR TITLE
Fix typos in setup output

### DIFF
--- a/dropbox_uploader.sh
+++ b/dropbox_uploader.sh
@@ -1585,7 +1585,7 @@ if [[ -e $CONFIG_FILE ]]; then
 #NEW SETUP...
 else
     echo -ne "\n This is the first time you run this script, please follow the instructions:\n\n"
-    echo -ne "(note: Dropropbox will change there API from 30.9.2021.\n"
+    echo -ne "(note: Dropbox will change their API on 2021-09-30.\n"
     echo -ne "When using dropbox_uploader.sh configured in the past with the old API, have a look at README.md, before continue.)\n\n"
     echo -ne " 1) Open the following URL in your Browser, and log in using your account: $APP_CREATE_URL\n"
     echo -ne " 2) Click on \"Create App\", then select \"Choose an API: Scoped Access\"\n"


### PR DESCRIPTION
Altered the second line of the Setup protocol output. 2 typos were fixed 1) "Dropropbox" -> "Dropbox" 2) "there" -> "their". I also changed the date from a region-specific format to a standard ISO 8601 compliant format: "30.09.2021" -> "2021-09-30". Finally, I changed "from" to "on" to be a little smoother in American English.