### PR TITLE
POC: Continues Integration for dropbox_uploaded

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,17 +6,17 @@ on:
   pull_request:
     branches:
     - main
-  env:
-    # The CI needs these three secrets set up on the repository 
-    # see https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository
-    OAUTH_APP_KEY: ${{ secrets.DROPBOX_OAUTH_APP_KEY }}
-    OAUTH_APP_SECRET: ${{ secrets.DROPBOX_OAUTH_APP_SECRET }}
-    OAUTH_REFRESH_TOKEN: ${{ secrets.DROPBOX_OAUTH_REFRESH_TOKEN }}
-    BASE_FOLDER: "repo/Dropbox-Uploader/pr"
 jobs:
   tests:
     name: Test E2E
     runs-on: ubuntu-latest
+    env:
+      # The CI needs these three secrets set up on the repository 
+      # see https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository
+      OAUTH_APP_KEY: ${{ secrets.DROPBOX_OAUTH_APP_KEY }}
+      OAUTH_APP_SECRET: ${{ secrets.DROPBOX_OAUTH_APP_SECRET }}
+      OAUTH_REFRESH_TOKEN: ${{ secrets.DROPBOX_OAUTH_REFRESH_TOKEN }}
+      BASE_FOLDER: "repo/Dropbox-Uploader/pr"
     steps:
       - uses: actions/checkout@v2
       - name: Setup Dropbox CLI 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,14 +31,12 @@ jobs:
           curl "https://raw.githubusercontent.com/livelyhood/Dropbox-Uploader/master/dropbox_uploader.sh" -o dropbox_uploader.sh
           chmod +x dropbox_uploader.sh
       - name: Test mkdir
-        id: collect_artifacts
         if: always() 
         run: |
           timestamp=$(date +%s)
           TEST_FOLDER=$timestamp
           ./dropbox_uploader.sh mkdir $BASE_FOLDER/$TEST_FOLDER
       - name: Test upload
-        id: collect_artifacts
         if: always() 
         run: |
           timestamp=$(date +%s)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
     branches:
     - main
   env:
+    # The CI needs these three secrets set up on the repository 
+    # see https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository
     OAUTH_APP_KEY: ${{ secrets.DROPBOX_OAUTH_APP_KEY }}
     OAUTH_APP_SECRET: ${{ secrets.DROPBOX_OAUTH_APP_SECRET }}
     OAUTH_REFRESH_TOKEN: ${{ secrets.DROPBOX_OAUTH_REFRESH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
           cat ~/.dropbox_uploader
           curl "https://raw.githubusercontent.com/livelyhood/Dropbox-Uploader/master/dropbox_uploader.sh" -o dropbox_uploader.sh
           chmod +x dropbox_uploader.sh
+          sleep 5s
+          ls -la
       - name: Test mkdir
         if: always() 
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup Dropbox CLI 
         run: |
-          sudo apt-get update
-          sudo apt-get install tree
           echo "CONFIGFILE_VERSION=2.0" > ~/.dropbox_uploader
           echo "OAUTH_APP_KEY=$OAUTH_APP_KEY" >> ~/.dropbox_uploader
           echo "OAUTH_APP_SECRET=$OAUTH_APP_SECRET" >> ~/.dropbox_uploader

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,21 +19,16 @@ jobs:
       BASE_FOLDER: "repo/Dropbox-Uploader/pr"
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Dropbox CLI 
+      - name: Setup Dropbox CLI Config
         run: |
           echo "CONFIGFILE_VERSION=2.0" > ~/.dropbox_uploader
           echo "OAUTH_APP_KEY=$OAUTH_APP_KEY" >> ~/.dropbox_uploader
           echo "OAUTH_APP_SECRET=$OAUTH_APP_SECRET" >> ~/.dropbox_uploader
           echo "OAUTH_REFRESH_TOKEN=$OAUTH_REFRESH_TOKEN" >> ~/.dropbox_uploader
           cat ~/.dropbox_uploader
-          curl "https://raw.githubusercontent.com/livelyhood/Dropbox-Uploader/master/dropbox_uploader.sh" -o dropbox_uploader.sh
           chmod +x dropbox_uploader.sh
           sleep 5s
           ls -la
-      - name: Test help
-        if: always() 
-        run: |
-          ./dropbox_uploader.sh
       - name: Test mkdir
         if: always() 
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: CI
 on:
   push:
     branches:
-    - main
+    - master
   pull_request:
     branches:
-    - main
+    - master
 jobs:
   tests:
     name: Test E2E

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+  env:
+    OAUTH_APP_KEY: ${{ secrets.DROPBOX_OAUTH_APP_KEY }}
+    OAUTH_APP_SECRET: ${{ secrets.DROPBOX_OAUTH_APP_SECRET }}
+    OAUTH_REFRESH_TOKEN: ${{ secrets.DROPBOX_OAUTH_REFRESH_TOKEN }}
+    BASE_FOLDER: "repo/Dropbox-Uploader/pr"
+jobs:
+  tests:
+    name: Test E2E
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Dropbox CLI 
+        run: |
+          sudo apt-get update
+          sudo apt-get install tree
+          echo "CONFIGFILE_VERSION=2.0" > ~/.dropbox_uploader
+          echo "OAUTH_APP_KEY=$OAUTH_APP_KEY" >> ~/.dropbox_uploader
+          echo "OAUTH_APP_SECRET=$OAUTH_APP_SECRET" >> ~/.dropbox_uploader
+          echo "OAUTH_REFRESH_TOKEN=$OAUTH_REFRESH_TOKEN" >> ~/.dropbox_uploader
+          cat ~/.dropbox_uploader
+          curl "https://raw.githubusercontent.com/livelyhood/Dropbox-Uploader/master/dropbox_uploader.sh" -o dropbox_uploader.sh
+          chmod +x dropbox_uploader.sh
+      - name: Test mkdir
+        id: collect_artifacts
+        if: always() 
+        run: |
+          timestamp=$(date +%s)
+          TEST_FOLDER=$timestamp
+          ./dropbox_uploader.sh mkdir $BASE_FOLDER/$TEST_FOLDER
+      - name: Test upload
+        id: collect_artifacts
+        if: always() 
+        run: |
+          timestamp=$(date +%s)
+          echo "timestamp" > timestamp.txt
+          ./dropbox_uploader.sh upload timestamp.txt $BASE_FOLDER
+      - name: 'Report Failure'
+        uses: actions/github-script@0.3.0
+        if: github.event_name == 'pull_request' && failure()
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { issue: { number: issue_number }, repo: { owner, repo } } = context;
+            github.issues.createComment({ issue_number, owner, repo, body: '💔 Oh No! The Tests Broke in Run ${{ github.run_number }} 💔!' });
+      - name: 'Report Success'
+        uses: actions/github-script@0.3.0
+        if: github.event_name == 'pull_request' && success()
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
+            github.issues.createComment({ issue_number, owner, repo, body: '💚 Yay! Your tests passed! 💚' });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,10 @@ jobs:
           chmod +x dropbox_uploader.sh
           sleep 5s
           ls -la
+      - name: Test help
+        if: always() 
+        run: |
+          ./dropbox_uploader.sh
       - name: Test mkdir
         if: always() 
         run: |


### PR DESCRIPTION
Hi @andreafabrizi !

I came across your dropbox_uploader after all other options (dropbox's limus client and dbxcli) didn't work for me.

The main problem was that I needed to upload folders in my GitHub Action workflows and the other options didn't let me manage the secrets easily.

I'm using dropbox_uploader in our automated tests and since I've all this working now, I thought you may like to use some of it for your own automated testing of dropbox_uploader. 

===

PR adds `ci.yml` github actions workflow (see https://docs.github.com/en/actions)

The tests run on every git push to the master branch and on every PR into the `master` branch:
<img width="272" alt="Screen Shot 2021-12-01 at 4 11 44 PM" src="https://user-images.githubusercontent.com/9286268/144314657-24bc9a38-0a8c-4189-9c79-fd3573c403ef.png">



The workflow assumes that the repository has access to these GitHub secrets:  DROPBOX_OAUTH_APP_KEY, DROPBOX_OAUTH_APP_SECRET, DROPBOX_OAUTH_REFRESH_TOKEN
```
      # The CI needs these three secrets set up on the repository  
      # see https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository
      OAUTH_APP_KEY: ${{ secrets.DROPBOX_OAUTH_APP_KEY }}
      OAUTH_APP_SECRET: ${{ secrets.DROPBOX_OAUTH_APP_SECRET }}
      OAUTH_REFRESH_TOKEN: ${{ secrets.DROPBOX_OAUTH_REFRESH_TOKEN }}

```

I have made them temporally available my Dropbox_Uploader [fork](https://github.com/livelyhood/Dropbox-Uploader), but revoked access after my PR passed  (so you cannot rerun the workflow anymore, it will fail)

Successful workflow run: https://github.com/livelyhood/Dropbox-Uploader/actions/runs/1527759907?check_suite_focus=true

Comments by the CI on the PR:

https://github.com/livelyhood/Dropbox-Uploader/pull/1



Failed workflow run: https://github.com/livelyhood/Dropbox-Uploader/runs/4387211689?check_suite_focus=true

Thanks for your tool!

Best 
Sebastian (penchef)